### PR TITLE
Set node-version 16

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '16'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 


### PR DESCRIPTION
Change node-version back from 17 to 16. This is because actions/node-versions does not yet support 17. See https://github.com/actions/node-versions and versions-manifest.json.