### PR TITLE
Set node-version 14

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '14'
           check-latest: true
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-          check-latest: true
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 


### PR DESCRIPTION
Use Node 14 to use local cache. actions/setup-node will first check the local cache and Node 14.18.1 is installed as runtime for Ubuntu 20.04.3 LTS of GitHub Actions Virtual Environments. See below.

- https://github.com/actions/setup-node
- https://github.com/actions/virtual-environments
- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md